### PR TITLE
사용자 등록 spy 테스트 추가

### DIFF
--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -2,6 +2,7 @@ package com.loopers.domain.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import com.loopers.utils.DatabaseCleanUp;
@@ -22,7 +24,7 @@ public class UserServiceIntegrationTest {
     @Autowired
     private UserService userService;
 
-    @Autowired
+    @SpyBean
     private UserRepository userRepository;
 
     @Autowired
@@ -32,6 +34,22 @@ public class UserServiceIntegrationTest {
     void tearDown() {
         databaseCleanUp.truncateAllTables();
     }
+
+
+    @DisplayName("회원 가입시 User 저장이 수행된다. (spy 검증)")
+    @Test
+    void register_spy_success() {
+        // given
+        UserRegisterRequest request = createUserRegisterRequest("testuser", "test@email.com", "1990-01-01");
+
+        // when
+        UserEntity result = userService.register(request);
+
+        // then
+        assertUserEntity(result, request);
+        verify(userRepository).save(any(UserEntity.class));
+    }
+
 
     @DisplayName("회원 가입시 User 저장이 수행된다.")
     @Test


### PR DESCRIPTION
## 📌 Summary

- UserService 회원가입 기능에 대한 spy 테스트 추가
- UserRepository mock 동작 검증을 통한 테스트 케이스 보강

## 💬 Review Points
- register_spy_success() 테스트에서 실제 DB 저장과 함께 userRepository.save() 호출 검증
- Spring Boot 3.4.0 이후 @SpyBean deprecated 이슈 대응 필요

## ✅ Checklist
- [x] spy 테스트 코드 구현 완료
- [x] 기존 테스트와의 중복성 검토
- [x] DB cleanup 로직 정상 동작 확인

## 📎 References

[Spring Boot Test Mock Features](https://docs.spring.io/spring-boot/reference/testing/spring-boot-applications.html#testing.spring-boot-applications.mocking-beans)
[SpyBean Deprecation Notice](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Release-Notes)